### PR TITLE
Make `loop_limit` a parameter of `contracts/calculations`

### DIFF
--- a/contracts/calculations-in-wasmi/src/lib.rs
+++ b/contracts/calculations-in-wasmi/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::all)]
 
-use wasmi::{Caller, Engine, Extern, Func, Linker, Module, Store};
+use std::collections::HashMap;
+use std::mem::size_of;
+
+use wasmi::{Caller, Engine, Extern, Func, Linker, Memory, Module, Store};
 
 // Host functions used in the contract.
 #[allow(unused)]
@@ -11,37 +14,114 @@ extern "C" {
     fn register_len(register_id: u64) -> u64;
 }
 
-/// Expects the bytes of compiled contract `contracts/calculations` as input.
+/// Host state related to the execution of wasm bytecode.
+///
+/// Instances are throwaway objects that must be used only for the execution of a single exported
+/// function, since the fields contain data specific to a `FunctionCallAction`.
+struct HostState {
+    /// The data the guest sees as its input and which it can access with the `input` host function.
+    ///
+    /// This data should live in `HostState` to avoid lifetime and ownership issues due to
+    /// constraints on host functions in `wasmi`, (see [`wasmi::Func::wrap`]).
+    input: Vec<u8>,
+    /// Some of these host functions read/write registers. We use a map to virtualize registers used
+    /// by the guest. Since the map only exists in memory, using `std::collections` is fine. If it
+    /// were written to storage, `near_sdk::collections` should be used.
+    registers: HashMap<u64, Vec<u8>>,
+}
+
+impl HostState {
+    fn new(input: Vec<u8>) -> Self {
+        Self {
+            input,
+            registers: HashMap::new(),
+        }
+    }
+
+    fn get_register_data(&self, register_id: u64) -> Vec<u8> {
+        match self.registers.get(&register_id) {
+            Some(data) => data.clone(),
+            None => vec![],
+        }
+    }
+}
+
+/// Expects input bytes correpsonding to:
+///
+/// - [0..4]: `loop_limit` to be passed to the interpreted wasm as `le_bytes` of an `u32`
+/// - [5..]: wasm of `contracts/calculations`
+///
+/// Working with raw byte input instead of (de)serialization libraries to avoid their overhead
+/// affecting benchmarks.
 #[no_mangle]
 pub unsafe fn cpu_ram_soak() {
-    // Get wasm bytecode from input.
+    // Get input data.
     const INPUT_REGISTER: u64 = 0;
     input(INPUT_REGISTER as u64);
-    let wasm = get_register_data(INPUT_REGISTER);
-    assert!(wasm.len() > 0, "Input should be wasm bytecode.");
+    let mut input_data = get_register_data(INPUT_REGISTER);
+    let min_input_len = size_of::<u32>() + 1; // + 1 to verify wasm bytecode is not empty
+    assert!(input_data.len() >= min_input_len, "unexpected input");
+
+    // Split input data. Cloning _small_ data to simplify ownership.
+    let loop_limit_bytes = input_data.drain(..4).collect::<Vec<u8>>().clone();
+    let wasm = input_data;
+
+    // Set up host state. We want the guest to see loop_limit_bytes as its input.
+    let host_state = HostState::new(loop_limit_bytes);
 
     // Set up the interpreter.
     let engine = Engine::default();
     let module = Module::new(&engine, &mut &wasm[..]).expect("should create `Module`");
-    type HostState = (); // a type is required, but for now we don't need state
-    let mut store = Store::new(&engine, ());
+    let mut store = Store::new(&engine, host_state);
 
     // Any host functions used in the interpreted wasm need to be available as imports in the
     // interpreter. Define the functions here.
+
+    // Writes input for `wasm` into the specified virtual guest register.
+    let host_fn_input = Func::wrap(
+        &mut store,
+        |mut caller: Caller<'_, HostState>, register_id: i64| {
+            let input = caller.data().input.clone();
+            caller
+                .data_mut()
+                .registers
+                .insert(register_id as u64, input);
+        },
+    );
+
+    // Allow the guest to write the data stored in a virtualized register to memory starting at
+    // `ptr`.
+    let host_fn_read_register = Func::wrap(
+        &mut store,
+        |caller: Caller<'_, HostState>, register_id: i64, ptr: i64| {
+            let data = caller
+                .data()
+                .get_register_data(register_id.try_into().unwrap());
+            let memory = get_exported_memory(&caller);
+            memory
+                .write(caller, ptr.try_into().unwrap(), &data)
+                .expect("should write memory");
+        },
+    );
+
+    // Allows the guest to get the byte-size of the data stored in `register_id`. Returns 0 if the
+    // register is empty.
+    let host_fn_register_len = Func::wrap(
+        &mut store,
+        |caller: Caller<'_, HostState>, register_id: i64| {
+            let data = caller
+                .data()
+                .get_register_data(register_id.try_into().unwrap());
+            data.len() as i64
+        },
+    );
 
     // Proxies Near's `log_utf` host function.
     let host_fn_log_utf8 = Func::wrap(
         &mut store,
         |caller: Caller<'_, HostState>, len: i64, ptr: i64| {
-            // Read data from guest memory.
-            //
-            // When compiling a contract written in Rust to `wasm32-unknown-unknown`, memory is
-            // exported under the name `memory`.
-            let memory = caller
-                .get_export("memory")
-                .and_then(Extern::into_memory)
-                .expect("should export memory");
             let mut msg = vec![0; len.try_into().unwrap()];
+            let memory = get_exported_memory(&caller);
             memory
                 .read(caller, ptr.try_into().unwrap(), &mut msg)
                 .expect("should read from interpreter's memory");
@@ -52,9 +132,14 @@ pub unsafe fn cpu_ram_soak() {
 
     // Create a `Linker` to link the module's imports and exports.
     let mut linker = <Linker<HostState>>::new(&engine);
+    linker.define("env", "input", host_fn_input).unwrap();
+    linker.define("env", "log_utf8", host_fn_log_utf8).unwrap();
     linker
-        .define("env", "log_utf8", host_fn_log_utf8)
-        .expect("should link host fn `log_utf8`");
+        .define("env", "read_register", host_fn_read_register)
+        .unwrap();
+    linker
+        .define("env", "register_len", host_fn_register_len)
+        .unwrap();
 
     // Instantiate the module. Before using the instance, `wasmi` requires calling `start()`.
     let instance = linker
@@ -70,6 +155,15 @@ pub unsafe fn cpu_ram_soak() {
     cpu_ram_soak
         .call(&mut store, ())
         .expect("should call the exported function")
+}
+
+/// Gets the memory that is exported by a wasm module written in Rust and compiled to
+/// `wasm32-unknown-unknown`.
+fn get_exported_memory(caller: &Caller<'_, HostState>) -> Memory {
+    caller
+        .get_export("memory")
+        .and_then(Extern::into_memory)
+        .expect("should export memory")
 }
 
 unsafe fn get_register_data(register_id: u64) -> Vec<u8> {

--- a/contracts/calculations-in-wasmi/src/lib.rs
+++ b/contracts/calculations-in-wasmi/src/lib.rs
@@ -63,7 +63,7 @@ pub unsafe fn cpu_ram_soak() {
     assert!(input_data.len() >= min_input_len, "unexpected input");
 
     // Split input data. Cloning _small_ data to simplify ownership.
-    let loop_limit_bytes = input_data.drain(..4).collect::<Vec<u8>>().clone();
+    let loop_limit_bytes = input_data.drain(..4).collect::<Vec<u8>>();
     let wasm = input_data;
 
     // Set up host state. We want the guest to see loop_limit_bytes as its input.
@@ -81,7 +81,7 @@ pub unsafe fn cpu_ram_soak() {
     let host_fn_input = Func::wrap(
         &mut store,
         |mut caller: Caller<'_, HostState>, register_id: i64| {
-            let input = caller.data().input.clone();
+            let input = caller.data().input.to_vec();
             caller
                 .data_mut()
                 .registers

--- a/contracts/calculations-in-wasmi/src/lib.rs
+++ b/contracts/calculations-in-wasmi/src/lib.rs
@@ -38,10 +38,10 @@ impl HostState {
         }
     }
 
-    fn get_register_data(&self, register_id: u64) -> Vec<u8> {
+    fn get_register_data(&self, register_id: u64) -> &[u8] {
         match self.registers.get(&register_id) {
-            Some(data) => data.clone(),
-            None => vec![],
+            Some(data) => &data,
+            None => &[],
         }
     }
 }
@@ -93,13 +93,14 @@ pub unsafe fn cpu_ram_soak() {
     // `ptr`.
     let host_fn_read_register = Func::wrap(
         &mut store,
-        |caller: Caller<'_, HostState>, register_id: i64, ptr: i64| {
+        |mut caller: Caller<'_, HostState>, register_id: i64, ptr: i64| {
             let data = caller
                 .data()
-                .get_register_data(register_id.try_into().unwrap());
+                .get_register_data(register_id.try_into().unwrap())
+                .to_owned();
             let memory = get_exported_memory(&caller);
             memory
-                .write(caller, ptr.try_into().unwrap(), &data)
+                .write(&mut caller, ptr.try_into().unwrap(), &data)
                 .expect("should write memory");
         },
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use workspaces::Worker;
 /// interpreting wasm.
 const METHOD_NAME: &str = "cpu_ram_soak";
 
+/// The number of iterations to execute in `contracts/calculations`.
+const LOOP_LIMIT: u32 = 100;
+
 #[tokio::main]
 async fn main() {
     let worker = workspaces::sandbox().await.expect("should spin up sandbox");
@@ -15,9 +18,13 @@ async fn main() {
     let wasm_calculations = workspaces::compile_project(project_path_native)
         .await
         .expect("should compile contracts/calculations");
-    let gas_burnt_native = profile_gas_usage(&worker, &wasm_calculations, vec![])
-        .await
-        .expect("should profile gas usage (native calculations");
+    let gas_burnt_native = profile_gas_usage(
+        &worker,
+        &wasm_calculations,
+        LOOP_LIMIT.to_le_bytes().to_vec(),
+    )
+    .await
+    .expect("should profile gas usage (native calculations");
     print_gas_burnt(project_path_native, gas_burnt_native);
 
     let project_path_wasmi = "./contracts/calculations-in-wasmi";
@@ -60,7 +67,10 @@ async fn profile_gas_usage(
     // executed in interpreted wasm. When interpreting wasm, the contract embedding the interpreter
     // is expected to forward guest logs to Near's `log_utf8`.
     // TODO make the number of loop iterations a parameter of `METHOD_NAME`, then remove hardcoded log here.
-    assert_eq!(vec!["Done 100 iterations!"], result.logs());
+    assert_eq!(
+        vec![format!("Done {LOOP_LIMIT} iterations!")],
+        result.logs()
+    );
 
     // The `FunctionCall` is the first and only action in above transaction. We want to consider
     // only the gas burnt by the corresponding receipt.


### PR DESCRIPTION
Prepares the repo for more elaborate benchmarking by making the number of loop iterations an input parameter of `contracts/calculations`’s method `cpu_ram_soak`.

For `contracts/calculations` this change is trivial. For `contracts/calculations-in-wasmi` it requires adding more host functions to the interpreter since the interpreted contract now reads input and accesses registers.